### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/johanines/4a84b8c8-7240-4a05-bec6-fb7ca6b184a1/fc6794cc-233e-4591-ad90-259a2b44f707/_apis/work/boardbadge/bcaa525c-ee6b-4130-99bb-db0122e6c33e)](https://dev.azure.com/johanines/4a84b8c8-7240-4a05-bec6-fb7ca6b184a1/_boards/board/t/fc6794cc-233e-4591-ad90-259a2b44f707/Microsoft.RequirementCategory)
 # Awesome Tools Front-end


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/johanines/4a84b8c8-7240-4a05-bec6-fb7ca6b184a1/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.